### PR TITLE
fix the inetnum and route object conflict problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ docker run -v path/to/registry:/registry -p 43:4343 --rm mic92/whois42d
 
 ```
 go mod init github.com/Mic92/whois42d
+go mod tidy
 make
 ```
 

--- a/whois/query.go
+++ b/whois/query.go
@@ -67,7 +67,9 @@ func (r *Registry) handleObject(conn *net.TCPConn, object Object, flags *Flags) 
 
 		if t.Kind == ROUTE || t.Kind == ROUTE6 {
 			if object[t.Kind] != nil {
-				found = found || r.printNet(conn, t.Name, object[t.Kind].(net.IP))
+				if r.printNet(conn, t.Name, object[t.Kind].(net.IP)) {
+					found = true
+				}
 			}
 		} else {
 			arg := object[t.Kind].(string)


### PR DESCRIPTION
In a whois query of a normal IP address such as `172.22.77.33`, the result shell contain both `inetnum` and `route` object if both exists, like this:

```
root@kskb-vm ~# echo "172.22.77.33" | nc 172.22.0.43 43
% This is the dn42 whois query service.

% Information related to 'inetnum/0.0.0.0_0':
inetnum:            0.0.0.0 - 255.255.255.255
cidr:               0.0.0.0/0
netname:            NET-BLK0-DN42
policy:             reserved
descr:              * The entire IPv4 address space
mnt-by:             DN42-MNT
status:             ALLOCATED
source:             DN42

% Information related to 'inetnum/172.20.0.0_14':
inetnum:            172.20.0.0 - 172.23.255.255
cidr:               172.20.0.0/14
netname:            NET-BLK014-DN42
policy:             reserved
mnt-by:             DN42-MNT
status:             ALLOCATED
source:             DN42

% Information related to 'inetnum/172.22.0.0_16':
inetnum:            172.22.0.0 - 172.22.255.255
cidr:               172.22.0.0/16
netname:            NET-BLK216-DN42
descr:              DN42 native address space
remarks:            Not free for direct assignments, please use sub-allocated blocks
nserver:            b.delegation-servers.dn42
nserver:            j.delegation-servers.dn42
nserver:            k.delegation-servers.dn42
ds-rdata:           64441 10 2 383a8c2714d3da76f58cee4c54566566b336b2dfa219b965f7cb706d71c54356
ds-rdata:           3096 10 2 5437ab49f1cd947d41c585c2cc9c357323013391b0e5f94784f99175142c3260
status:             ALLOCATED
policy:             reserved
org:                ORG-DN42
mnt-by:             DN42-MNT
source:             DN42

% Information related to 'inetnum/172.22.64.0_18':
inetnum:            172.22.64.0 - 172.22.127.255
cidr:               172.22.64.0/18
netname:            NET-BLK26418-DN42
descr:              DN42 native address space
remarks:            * Default allocation /27, never more than /24
policy:             open
mnt-by:             DN42-MNT
status:             ALLOCATED
source:             DN42

% Information related to 'inetnum/172.22.77.32_28':
inetnum:            172.22.77.32 - 172.22.77.47
netname:            KSKB-IPV4
remarks:            Peer with me at mailto:dn42@kskb.eu.org or https://t.me/KusakabeSi
descr:              Peer with me at mailto:dn42@kskb.eu.org or https://t.me/KusakabeSi
country:            TW
admin-c:            KSKB-DN42
tech-c:             KSKB-DN42
mnt-by:             KSKB-MNT
nserver:            ns1.kskb.dn42
nserver:            ns2.kskb.dn42
status:             ASSIGNED
cidr:               172.22.77.32/28
source:             DN42

% Information related to 'route/172.22.77.32_28':
route:              172.22.77.32/28
descr:              Peer with me at mailto:dn42@kskb.eu.org or https://t.me/KusakabeSi
origin:             AS4242421817
mnt-by:             KSKB-MNT
source:             DN42
```

But your version **drops all following results** while first result found:
```
root@kskb-vm ~# echo "172.22.77.33" | nc 127.0.0.1 43
% This is the dn42 whois query service.

% Information related to 'inetnum/0.0.0.0_0':
inetnum:            0.0.0.0 - 255.255.255.255
cidr:               0.0.0.0/0
netname:            NET-BLK0-DN42
policy:             reserved
descr:              * The entire IPv4 address space
mnt-by:             DN42-MNT
status:             ALLOCATED
source:             DN42

% Information related to 'inetnum/172.20.0.0_14':
inetnum:            172.20.0.0 - 172.23.255.255
cidr:               172.20.0.0/14
netname:            NET-BLK014-DN42
policy:             reserved
mnt-by:             DN42-MNT
status:             ALLOCATED
source:             DN42

% Information related to 'inetnum/172.22.0.0_16':
inetnum:            172.22.0.0 - 172.22.255.255
cidr:               172.22.0.0/16
netname:            NET-BLK216-DN42
descr:              DN42 native address space
remarks:            Not free for direct assignments, please use sub-allocated blocks
nserver:            b.delegation-servers.dn42
nserver:            j.delegation-servers.dn42
nserver:            k.delegation-servers.dn42
ds-rdata:           64441 10 2 383a8c2714d3da76f58cee4c54566566b336b2dfa219b965f7cb706d71c54356
ds-rdata:           3096 10 2 5437ab49f1cd947d41c585c2cc9c357323013391b0e5f94784f99175142c3260
status:             ALLOCATED
policy:             reserved
org:                ORG-DN42
mnt-by:             DN42-MNT
source:             DN42

% Information related to 'inetnum/172.22.64.0_18':
inetnum:            172.22.64.0 - 172.22.127.255
cidr:               172.22.64.0/18
netname:            NET-BLK26418-DN42
descr:              DN42 native address space
remarks:            * Default allocation /27, never more than /24
policy:             open
mnt-by:             DN42-MNT
status:             ALLOCATED
source:             DN42

% Information related to 'inetnum/172.22.77.32_28':
inetnum:            172.22.77.32 - 172.22.77.47
netname:            KSKB-IPV4
remarks:            Peer with me at mailto:dn42@kskb.eu.org or https://t.me/KusakabeSi
descr:              Peer with me at mailto:dn42@kskb.eu.org or https://t.me/KusakabeSi
country:            TW
admin-c:            KSKB-DN42
tech-c:             KSKB-DN42
mnt-by:             KSKB-MNT
nserver:            ns1.kskb.dn42
nserver:            ns2.kskb.dn42
status:             ASSIGNED
cidr:               172.22.77.32/28
source:             DN42
```

this part is missing in your result: 
```
% Information related to 'route/172.22.77.32_28':
route:              172.22.77.32/28
descr:              Peer with me at mailto:dn42@kskb.eu.org or https://t.me/KusakabeSi
origin:             AS4242421817
mnt-by:             KSKB-MNT
source:             DN42
```

the reason why this happen is in your `whois/query.go` line 70, the `r.printNet` function will not execute if the `found` is true.
```go
a := true
a = a || functionXXX()
// functionXXX() will not be evaluated
```

So this Pull Request fix it.